### PR TITLE
Ignore errors about Symfony's dispatcher in PHPStan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,13 @@
 includes:
-	- vendor/phpstan/phpstan-mockery/extension.neon
+    - vendor/phpstan/phpstan-mockery/extension.neon
 
 parameters:
     excludes_analyse:
         - %rootDir%/../../../src/ServiceContainer/MailhogExtension.php
         - %rootDir%/../../../tests/ServiceContainer/MailhogExtensionTest.php
+    ignoreErrors:
+        -
+            # symfony/dispatcher dispatch() changed from (string, object) to (object[, string]) in 4.3
+            message: '~Symfony\\Component\\EventDispatcher\\EventDispatcher::dispatch\(\).~'
+            path: tests/Listener/EmailPurgeListenerTest.php
+    reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
Method signature of dispatch changed from 4.2 to 4.3. Since the old
method is still supported, we'll ignore the warning for now.