### PR TITLE
Tighten composer package versions for faster installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,17 +25,17 @@
         "behat/behat": "^3.0.11",
         "rpkamp/mailhog-client": "^0.3.5",
         "php-http/discovery": "^1.3",
-        "symfony/dependency-injection": "~2.7 || ~3.0 || ~4.0"
+        "symfony/dependency-injection": "~3.4 || ~4.0"
     },
     "require-dev": {
-        "guzzlehttp/psr7": "^1.4",
+        "guzzlehttp/psr7": "^1.6",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "php-http/curl-client": "^1.7",
-        "squizlabs/php_codesniffer": "^3.3.1",
-        "swiftmailer/swiftmailer": "^6.0",
-        "phpunit/phpunit": "^8.0",
-        "mockery/mockery": "^1.2.1",
-        "phpstan/phpstan": "^0.11",
-        "phpstan/phpstan-mockery": "^0.11"
+        "squizlabs/php_codesniffer": "^3.4.2",
+        "swiftmailer/swiftmailer": "^6.2",
+        "phpunit/phpunit": "^8.3.4",
+        "mockery/mockery": "^1.2.3",
+        "phpstan/phpstan": "^0.11.15",
+        "phpstan/phpstan-mockery": "^0.11.3"
     }
 }


### PR DESCRIPTION
Especially --prefer-lowest for composer was very slow (about half an
hour) is now down to about half a minute