### PR TITLE
Search through all messages when looking for a message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.2",
         "behat/behat": "^3.0.11",
-        "rpkamp/mailhog-client": "^0.3.5",
+        "rpkamp/mailhog-client": "^0.4",
         "php-http/discovery": "^1.3",
         "symfony/dependency-injection": "~3.4 || ~4.0"
     },

--- a/features/tests.feature
+++ b/features/tests.feature
@@ -1,11 +1,11 @@
 Feature: As the developer of this context I want it to function correctly
 
-  Scenario: As a user I want to receive an email
+  Scenario: As a user I want to check that an email was sent
     Given I send an email with subject "Hello" and body "How are you?" to "test@example.org"
     Then I should see an email with subject "Hello"
     And I should see an email with body "How are you?"
     And I should see an email from "me@myself.example"
-    And I should see an email from "Myself"
+    And I should see an email from "Myself <me@myself.example>"
     And I should see an email with subject "Hello" and body "How are you?"
     And I should see an email with subject "Hello" and body "How are you?" from "me@myself.example"
     And I should see an email with subject "Hello" from "me@myself.example"
@@ -14,10 +14,17 @@ Feature: As the developer of this context I want it to function correctly
     And I should see an email with subject "Hello" to "test@example.org"
     And I should see an email with body "How are you?" to "test@example.org"
     And I should see an email from "me@myself.example" to "test@example.org"
-    And I should see an email from "Myself" to "test@example.org"
+    And I should see an email from "Myself <me@myself.example>" to "test@example.org"
     And I should see an email with subject "Hello" and body "How are you?" to "test@example.org"
     And I should see an email with subject "Hello" and body "How are you?" from "me@myself.example" to "test@example.org"
     And I should see an email with subject "Hello" from "me@myself.example" to "test@example.org"
+
+  Scenario: As a user I want to check that an email was sent even if other emails were sent after it
+    Given I send an email with subject "Goodbye" and body "It was nice to see you!" to "foo@example.org"
+    Given I send an email with subject "Hello" and body "How are you?" to "test@example.org"
+    Then I should see an email with subject "Goodbye"
+    And I should see an email with body "It was nice to see you!"
+    And I should see "nice" in email
 
   Scenario: As a user I want to open an email based on subject
     Given I send an email with subject "Hello" and body "How are you?" to "test@example.org"
@@ -53,4 +60,9 @@ Feature: As the developer of this context I want it to function correctly
 
   Scenario: As a developer I want the extension to see attachments in emails
     Given I send an email with attachment "hello.txt"
+    Then I should see an email with attachment "hello.txt"
+
+  Scenario: As a developer I want the extension to see attachments in emails even if other emails were sent after
+    Given I send an email with attachment "hello.txt"
+    Given I send an email with attachment "foo.txt"
     Then I should see an email with attachment "hello.txt"


### PR DESCRIPTION
Before this extension would mostly only look if the last sent message
adhered to some criteria, but now it will look through all messages in
the inbox to see if there is any message matching the criteria.

That does mean that searching might be slower, because it will go
through the entire mailhog inbox for each search.

Make sure to purge the mailbox every once in a while to avoid it getting
too slow.