### PR TITLE
Allowing specification on body when opening email

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Then I should see an email with from "sender@domain.example"
 Then I should see an email with subject "subject" and body "body"
 Then I should see an email with subject "subject" and body "body" from "sender@domain.example"
 Then I should see an email with subject "subject" from "sender@domain.example"
+Then I should see an email to "recipient@domain.example"
+Then I should see an email with subject "subject" to "recipient@domain.example"
+Then I should see an email with body "body" to "recipient@domain.example"
+Then I should see an email from "sender@domain.example" to "recipient@domain.example"
+Then I should see an email with subject "subject" and body "body" to "recipient@domain.example"
+Then I should see an email with subject "subject" and body "body" from "sender@domain.example" to "recipient@domain.example"
+Then I should see an email with subject "subject" from "sender@domain.example" to "recipient@domain.example"
 Then I should see "some text" in email
 Then there should be 2 emails in my inbox
 Then I should see an email with attachment "lorem-ipsum.pdf"
@@ -69,7 +76,14 @@ When I open the latest email to "recipient@domain.example"
 When I open the latest email with subject "Hello world"
 When I open the latest email from "sender@domain.example" with subject "Hello world"
 When I open the latest email to "recipient@domain.example" with subject "Hello world"
-
+When I open the latest email with body "body"
+When I open the latest email with subject "subject" and body "body"
+When I open the latest email from "sender@domain.example" to "recipient@domain.example"
+When I open the latest email from "sender@domain.example" with body "body"
+When I open the latest email to "recipient@domain.example" with body "body"
+When I open the latest email from "sender@domain.example" with subject "subject" and body "body"
+When I open the latest email to "recipient@domain.example" with subject "subject" and body "body"
+When I open the latest email from "sender@domain.example" to "recipient@domain.example" with subject "subject" and body "body"
 Then I should see "Hello world" in the opened email
 Then I should see an attachment with filename "lorem-ipsum.pdf" in the opened email
 ```

--- a/features/tests.feature
+++ b/features/tests.feature
@@ -44,6 +44,12 @@ Feature: As the developer of this context I want it to function correctly
     When I open the latest email to "test@example.org"
     Then I should see "See you later" in the opened email
 
+  Scenario: As as user I want to open an email based on body
+    Given I send an email with subject "Hello" and body "How are you?" to "test@example.org"
+    Given I send an email with subject "Goodbye" and body "See you later" to "test@example.org"
+    When I open the latest email with body "How are you?"
+    Then I should see "How are you?" in the opened email
+
   Scenario: As a user I want to check for an attachment in an opened email
     Given I send an email with attachment "hello.txt"
     When I open the latest email from "me@myself.example"


### PR DESCRIPTION
Like the title says, allowing the BodySpecification to be used when opening emails.
Also updated the step definitions as there are more possible ways to use the context methods.

Thanks in advance for your time and effort.



